### PR TITLE
Add OSGI bundle headers during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
     <groupId>net.sourceforge.streamsupport</groupId>
     <artifactId>java9-concurrent-backport</artifactId>
     <version>2.0.4</version>
+    <packaging>bundle</packaging>
     <name>net.sourceforge.streamsupport:java9-concurrent-backport</name>
     <description>Backport of Java 9 CompletableFuture, Flow and SubmissionPublisher API for Java 8</description>
     <url>https://github.com/stefan-zobel/java9-concurrent-backport/</url>
@@ -79,6 +80,12 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>4.2.1</version>
+                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
OSGI bundle headers are added using the maven-bundle-plugin.
To enable it, the packaging is changed from jar to bundle.

Closes #3 